### PR TITLE
Update benchmark runner

### DIFF
--- a/test/bluebird.js
+++ b/test/bluebird.js
@@ -1,0 +1,3 @@
+const bench = require('./index.js');
+global.Promise = require('bluebird');
+bench('Bluebird: ');

--- a/test/index.js
+++ b/test/index.js
@@ -34,19 +34,17 @@ function evalTemplate(tpl) {
 // Pre-compile the test doc into a template (array of chunks). Our handler
 // returns functions for dynamic elements, so that we can re-evaluate the
 // template at runtime.
-function bench(msg) {
-    var startTime = Date.now();
-    var n = 500000;
-    function iter(i) {
-        return evalTemplate(precompiledTemplate)
-            .then(() => i ? iter(i - 1) : null);
-    }
-    return iter(n).then(() => {
-        console.log(msg, (Date.now() - startTime) / n, 'ms per iteration');
+module.exports = function(kind) {
+  var startTime = Date.now();
+  var n = 50000;
+  var count = 0;
+
+  for (var i = 0; i <= n; i++) {
+    evalTemplate(precompiledTemplate).then(() => {
+      count++;
+      if ( count === n ) {
+        console.log(kind, (Date.now() - startTime) / n, 'ms per iteration');
+      }
     });
+  }
 }
-bench('Native Promise:')
-.then(() => {
-    global.Promise = require('bluebird');
-    return bench('Bluebird:');
-});

--- a/test/native.js
+++ b/test/native.js
@@ -1,0 +1,2 @@
+const bench = require('./index.js');
+bench('Native: ');


### PR DESCRIPTION
This PR updates the benchmark runner to be more consistent and not distort the actual bench marking code. 

Running the benchmark with native promises first causes the benchmark code to get hot and get optimized during this first run. This means that the native promises run is actually including the compile time cost, but the subsequent run with bluebird doesn't incur the compile time cost. 

The actual benchmark work is done in evalTemplate, which reads/writes to a stream using Promises, but by making the benchmark runner work using promises, the result is distorted. When returning a promise from within a onFulfilled handler, the ES spec requires us to create a new promise, whilst having references to the old promise, to maintain the microtask queue order invariance. Bluebird and other polyfills are not ES spec compliant and instead migrate the callbacks causing changes in the microtask queue ordering. Here's a more in depth explanation with an example --
https://bugs.chromium.org/p/v8/issues/detail?id=5002#c4

This PR splits the bluebird and native benchmarks into separate files and changes the runner to use a simple for loop.

The current tip of tree V8 has improved ~66% when compared to V8 5.3, back when work on Promises was started. The current tip of tree is also ~11% faster than the bluebird version.

V8 5.2 - 0.0453 ms per iteration
ToT V8 -  0.015 ms per iteration
Bluebird - 0.0168 ms per iteraton